### PR TITLE
Add Homebrew formula

### DIFF
--- a/Formula/orus.rb
+++ b/Formula/orus.rb
@@ -1,0 +1,19 @@
+class Orus < Formula
+  desc "Experimental stack-based virtual machine and language"
+  homepage "https://github.com/jordyorel/Orus-lang-Stack-based-VM"
+  url "https://github.com/jordyorel/Orus-lang-Stack-based-VM/archive/2a3f12ab16607078bcf5652d20c5d26c471872c5.tar.gz"
+  sha256 "341c18cb0202fa33b0bd3c690fdb92c2587d671ca121b019c3ec5f92c9060818"
+  version "0.3.0"
+  license "MIT"
+  head "https://github.com/jordyorel/Orus-lang-Stack-based-VM.git", branch: "main"
+
+  def install
+    system "make", "orusc"
+    bin.install "orusc"
+  end
+
+  test do
+    (testpath/"hello.orus").write('print("hello brew")')
+    assert_equal "hello brew\n", shell_output("#{bin}/orusc #{testpath}/hello.orus")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ make clean
 
 The build process places the final executable in `./orusc` and also keeps a copy in `build/release/clox`.
 
+## Homebrew Installation
+
+If you use [Homebrew](https://brew.sh) on macOS or Linux, a tap is provided so that
+the interpreter can be installed with a simple `brew install orus`:
+
+```sh
+brew tap jordyorel/orus
+brew install orus
+```
+
+The tap builds the latest release of the project. If you prefer to build from the
+checked‑out repository instead, run:
+
+```sh
+brew install --build-from-source ./Formula/orus.rb
+```
+
+Both methods install the `orusc` executable into Homebrew's `bin` directory.
+
 ## Running
 
 After building, run the interpreter in two ways:


### PR DESCRIPTION
## Summary
- add `Formula/orus.rb` with a Homebrew formula for the interpreter
- document how to install Orus with Homebrew via a tap for `brew install orus`\