### PR TITLE
Add integer promotion and overflow tests

### DIFF
--- a/tests/edge_cases/i64_overflow.orus
+++ b/tests/edge_cases/i64_overflow.orus
@@ -1,0 +1,5 @@
+fn main() {
+    let max: i64 = 9_223_372_036_854_775_807
+    let res = max + 1
+    print(res)
+}

--- a/tests/edge_cases/integer_promotion_sum.orus
+++ b/tests/edge_cases/integer_promotion_sum.orus
@@ -1,0 +1,10 @@
+fn main() {
+    let start = timestamp()
+    let mut sum = 0
+    for i in 0..1_000_000 {
+        sum += i
+    }
+    print("Sum: {}", sum)
+    let elapsed = timestamp() - start
+    print("Time elapsed: {}", elapsed)
+}

--- a/tests/edge_cases/integer_promotion_underflow.orus
+++ b/tests/edge_cases/integer_promotion_underflow.orus
@@ -1,0 +1,5 @@
+fn main() {
+    let mut x = -2147483648
+    x -= 1
+    print(x)
+}


### PR DESCRIPTION
## Summary
- add test for summation with auto integer promotion
- add test covering i32 underflow promotion
- add test for i64 overflow handling

## Testing
- `bash tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d8dcb875883259d73c0b3211d060b